### PR TITLE
Constructive Solid Geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # HEAD
 
+## 2025-06-19
+- Start supporting Constructive Solid Geometry [PR#15](https://github.com/matteoilardi/Raytracer/pull/15)
+
 ## 2025-06-09
 - Implement lexer and parser supporting scene description in a source file [PR#13](https://github.com/matteoilardi/Raytracer/pull/13)
 

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Render a scene described in a custom text-based file format:
 The scene file uses a custom format supporting:
 - Camera orientation
 - Materials definition
-- Object creation and transformation
-- Variable substitution with command-line overrides (`--define-float`)
+- Object creation using base shapes (currently spheres and planes), with support for Constructive Solid Geometry (CSG) operations
+- Variable substitution with command-line overrides (via `--define-float`)
 
-See `samples/demo_scene.txt` for usage. A formal EBNF grammar description will be provided soon, along with more examples and use cases.
+See `samples/demo_scene.txt` and `samples/csg_example.txt` for usage. A formal EBNF grammar description will be provided soon, along with more examples and use cases.
 
 ---
 

--- a/include/cameras.hpp
+++ b/include/cameras.hpp
@@ -62,7 +62,7 @@ public:
 
   /// @brief apply a transformation to the ray (origin transformed like a point, direction transformed like a vector)
   /// @param transformation to be applied
-  Ray transform(Transformation T) { return Ray(T * origin, T * direction, tmin, tmax, depth); };
+  Ray transform(Transformation T) const { return Ray(T * origin, T * direction, tmin, tmax, depth); };
 };
 
 // ------------------------------------------------------------------------------------------------------------

--- a/include/scenefiles.hpp
+++ b/include/scenefiles.hpp
@@ -73,17 +73,33 @@ enum class KeywordEnum {
 };
 
 /// @brief map of keywords to their enum values
-const std::unordered_map<std::string, KeywordEnum> KEYWORDS = {
-    {"material", KeywordEnum::MATERIAL},    {"infer", KeywordEnum::INFER},    {"plane", KeywordEnum::PLANE},
-    {"sphere", KeywordEnum::SPHERE},      {"csg", KeywordEnum::CSG},  {"union", KeywordEnum::UNION}, {"intersection", KeywordEnum::INTERSECTION}, {"difference", KeywordEnum::DIFFERENCE}, {"fusion", KeywordEnum::FUSION}, {"norender", KeywordEnum::NORENDER}, {"diffuse", KeywordEnum::DIFFUSE},
-    {"specular", KeywordEnum::SPECULAR},       {"uniform", KeywordEnum::UNIFORM},
-    {"checkered", KeywordEnum::CHECKERED},     {"image", KeywordEnum::IMAGE},
-    {"identity", KeywordEnum::IDENTITY},       {"translation", KeywordEnum::TRANSLATION},
-    {"rotation_x", KeywordEnum::ROTATION_X},   {"rotation_y", KeywordEnum::ROTATION_Y},
-    {"rotation_z", KeywordEnum::ROTATION_Z},   {"scaling", KeywordEnum::SCALING},
-    {"camera", KeywordEnum::CAMERA},           {"orthogonal", KeywordEnum::ORTHOGONAL},
-    {"perspective", KeywordEnum::PERSPECTIVE}, {"exact_asp_ratio", KeywordEnum::EXACT_ASP_RATIO}, {"float", KeywordEnum::FLOAT},
-    {"point_light", KeywordEnum::POINT_LIGHT}};
+const std::unordered_map<std::string, KeywordEnum> KEYWORDS = {{"material", KeywordEnum::MATERIAL},
+                                                               {"infer", KeywordEnum::INFER},
+                                                               {"plane", KeywordEnum::PLANE},
+                                                               {"sphere", KeywordEnum::SPHERE},
+                                                               {"csg", KeywordEnum::CSG},
+                                                               {"union", KeywordEnum::UNION},
+                                                               {"intersection", KeywordEnum::INTERSECTION},
+                                                               {"difference", KeywordEnum::DIFFERENCE},
+                                                               {"fusion", KeywordEnum::FUSION},
+                                                               {"norender", KeywordEnum::NORENDER},
+                                                               {"diffuse", KeywordEnum::DIFFUSE},
+                                                               {"specular", KeywordEnum::SPECULAR},
+                                                               {"uniform", KeywordEnum::UNIFORM},
+                                                               {"checkered", KeywordEnum::CHECKERED},
+                                                               {"image", KeywordEnum::IMAGE},
+                                                               {"identity", KeywordEnum::IDENTITY},
+                                                               {"translation", KeywordEnum::TRANSLATION},
+                                                               {"rotation_x", KeywordEnum::ROTATION_X},
+                                                               {"rotation_y", KeywordEnum::ROTATION_Y},
+                                                               {"rotation_z", KeywordEnum::ROTATION_Z},
+                                                               {"scaling", KeywordEnum::SCALING},
+                                                               {"camera", KeywordEnum::CAMERA},
+                                                               {"orthogonal", KeywordEnum::ORTHOGONAL},
+                                                               {"perspective", KeywordEnum::PERSPECTIVE},
+                                                               {"exact_asp_ratio", KeywordEnum::EXACT_ASP_RATIO},
+                                                               {"float", KeywordEnum::FLOAT},
+                                                               {"point_light", KeywordEnum::POINT_LIGHT}};
 
 /// @brief convert a keyword enum to its string representation (for debugging and printing)
 std::string to_string(KeywordEnum kw) {
@@ -603,7 +619,7 @@ public:
   std::shared_ptr<Camera> camera = nullptr;                             // camera used for firing rays
   std::unordered_map<std::string, float> float_variables;               // float identifiers table
   std::unordered_set<std::string> overwritten_variables; // set of float identifiers that can be overwritten from command line
-  std::unordered_map<std::string, std::shared_ptr<Shape>> objects;      // map of object (shape) names to Shape objects
+  std::unordered_map<std::string, std::shared_ptr<Shape>> objects; // map of object (shape) names to Shape objects
 
   // -------- constructors --------
   Scene() : world(std::make_shared<World>()) {}
@@ -649,8 +665,7 @@ public:
       }
       return map_it->second; // Otherwise return the value of the variable stored in the `dictionary'
     } else {
-      throw GrammarError(token.source_location,
-                         "expected LITERAL_NUMBER or IDENTIFIER instead of " + token.type_to_string());
+      throw GrammarError(token.source_location, "expected LITERAL_NUMBER or IDENTIFIER instead of " + token.type_to_string());
     }
   }
 
@@ -873,12 +888,11 @@ public:
     return std::make_shared<Plane>(plane_transformation, materials_it->second);
   }
 
-
   /// @brief parse a general object, which may be specified by an indentifier or an inline definition
   std::shared_ptr<Shape> parse_object(InputStream &input_stream) {
     Token new_token = input_stream.read_token();
     if (new_token.type == TokenKind::IDENTIFIER) {
-      const std::string& object_name = std::get<std::string>(new_token.value);
+      const std::string &object_name = std::get<std::string>(new_token.value);
       if (objects.contains(object_name)) {
         return objects[object_name];
       } else {
@@ -913,7 +927,8 @@ public:
     // Parse CSG operation
     CSGObject::Operation operation;
     SourceLocation location = input_stream.location;
-    KeywordEnum operation_keyword = expect_keywords(input_stream, {KeywordEnum::UNION, KeywordEnum::INTERSECTION, KeywordEnum::DIFFERENCE, KeywordEnum::FUSION});
+    KeywordEnum operation_keyword = expect_keywords(
+        input_stream, {KeywordEnum::UNION, KeywordEnum::INTERSECTION, KeywordEnum::DIFFERENCE, KeywordEnum::FUSION});
     switch (operation_keyword) {
     case KeywordEnum::UNION:
       operation = CSGObject::Operation::UNION;
@@ -945,7 +960,7 @@ public:
       input_stream.unread_token(new_token);
 
       SourceLocation source_location =
-        input_stream.location; // Save location of the material identifier token in case an exception needs to be raised
+          input_stream.location; // Save location of the material identifier token in case an exception needs to be raised
       std::string material_identifier = expect_identifier(input_stream);
       auto materials_it = materials.find(material_identifier); // Look for the material in the material map
       if (materials_it == materials.end()) {                   // If not found, throw an error
@@ -1020,9 +1035,11 @@ public:
   // TODO perhaps you want to allow the user to provide arguments in a different order and to omit emission_radius
 
   /// @brief Parse a scene from a stream
-  /// @details It is meant to be called after initialize_float_variables_with_priority() if you want to overwrite float vars from command line
+  /// @details It is meant to be called after initialize_float_variables_with_priority() if you want to overwrite float vars from
+  /// command line
   void parse_scene(InputStream &input_stream) {
-    // The scene actually consists of a sequence of definitions. The user is allowed to define the following types: float, material, sphere, plane, camera, point_light
+    // The scene actually consists of a sequence of definitions. The user is allowed to define the following types: float,
+    // material, sphere, plane, camera, point_light
     while (true) {
       // Check for end of stream or norender keyword
       Token new_token = input_stream.read_token();
@@ -1040,8 +1057,9 @@ public:
       if (norender) {
         keyword = expect_keywords(input_stream, {KeywordEnum::SPHERE, KeywordEnum::PLANE, KeywordEnum::CSG});
       } else {
-        keyword = expect_keywords(input_stream, {KeywordEnum::FLOAT, KeywordEnum::MATERIAL, KeywordEnum::SPHERE,
-                                                           KeywordEnum::PLANE, KeywordEnum::CSG, KeywordEnum::CAMERA, KeywordEnum::POINT_LIGHT});
+        keyword =
+            expect_keywords(input_stream, {KeywordEnum::FLOAT, KeywordEnum::MATERIAL, KeywordEnum::SPHERE, KeywordEnum::PLANE,
+                                           KeywordEnum::CSG, KeywordEnum::CAMERA, KeywordEnum::POINT_LIGHT});
       }
 
       switch (keyword) {
@@ -1093,7 +1111,8 @@ public:
 
           // Throw if an object with the same name has already been defined
           if (objects.count(sphere_name)) {
-            throw GrammarError(source_location, "object with name \"" + sphere_name + "\" already declared elsewhere in the file");
+            throw GrammarError(source_location,
+                               "object with name \"" + sphere_name + "\" already declared elsewhere in the file");
           }
 
           // Add Sphere to World
@@ -1192,12 +1211,13 @@ public:
     }
   }
 
-  void initialize_float_variables_with_priority(std::unordered_map<std::string, float>&& variables_from_cl) {
+  void initialize_float_variables_with_priority(std::unordered_map<std::string, float> &&variables_from_cl) {
     // Actually to be fair the *priority* which we refer to is enforced by the method parse_scene(): case KeywordEnum::FLOAT
-    assert(float_variables.empty()); // For the logic of parse_scene() to work correctly, float variables from command line are to be parsed and added to float_variables before parsing the scene file
+    assert(float_variables.empty()); // For the logic of parse_scene() to work correctly, float variables from command line are to
+                                     // be parsed and added to float_variables before parsing the scene file
 
     float_variables = std::move(variables_from_cl);
-    for (const auto& name : float_variables) {
+    for (const auto &name : float_variables) {
       overwritten_variables.insert(name.first);
     }
   }

--- a/include/shapes.hpp
+++ b/include/shapes.hpp
@@ -478,7 +478,7 @@ public:
     }
   }
 
-  void _apply_csg_transformation_and_material(std::vector<HitRecord> hits) const {
+  void _apply_csg_transformation_and_material(std::vector<HitRecord>& hits) const {
     // Apply CSGObject global Transformation to all hits if transformation is defined
     for (auto& hit : hits) {
       hit.world_point = transformation * hit.world_point;

--- a/include/shapes.hpp
+++ b/include/shapes.hpp
@@ -405,7 +405,7 @@ public:
       if (it2 == intersections2.end()) {
         break; // If you reach end of vector 2, perform final checks on vector 1 separately, outside of the loop
       }
-      if (it1->t < it2->t) { // Compare valid intersections with shae 1 and 2 and choose the one with smaller t
+      if (it1->t < it2->t) { // Compare valid intersections with shape 1 and 2 and choose the one with smaller t
         result.push_back(*it1);
         ++it1;
       } else {

--- a/include/shapes.hpp
+++ b/include/shapes.hpp
@@ -465,17 +465,16 @@ public:
   }
 
   virtual bool is_point_inside(const Point& point_world_frame) const override {
-    Point point_csg_frame = point_world_frame;
-    // Point point_csg_frame = transformation.inverse() * point_world_frame;
+    Point point_csg_frame = transformation.inverse() * point_world_frame;
     switch (operation) {
     case Operation::UNION:
-      return object1->is_point_inside(point_world_frame) || object2->is_point_inside(point_world_frame);
+      return object1->is_point_inside(point_csg_frame) || object2->is_point_inside(point_csg_frame);
     case Operation::INTERSECTION:
-      return object1->is_point_inside(point_world_frame) && object2->is_point_inside(point_world_frame);
+      return object1->is_point_inside(point_csg_frame) && object2->is_point_inside(point_csg_frame);
     case Operation::DIFFERENCE:
-      return object1->is_point_inside(point_world_frame) && !object2->is_point_inside(point_world_frame);
+      return object1->is_point_inside(point_csg_frame) && !object2->is_point_inside(point_csg_frame);
     case Operation::FUSION:
-      return object1->is_point_inside(point_world_frame) || object2->is_point_inside(point_world_frame); // same as union
+      return object1->is_point_inside(point_csg_frame) || object2->is_point_inside(point_csg_frame); // same as union
     }
   }
 

--- a/include/shapes.hpp
+++ b/include/shapes.hpp
@@ -211,6 +211,7 @@ public:
       return std::vector<HitRecord>();
     }
 
+    // 3. Keep all the valid intersections (at most 2)
     std::vector<float> t_hits;
     float t1 = (-O * ray.direction - std::sqrt(reduced_discriminant)) / ray.direction.squared_norm();
     float t2 = (-O * ray.direction + std::sqrt(reduced_discriminant)) / ray.direction.squared_norm();
@@ -223,14 +224,13 @@ public:
       t_hits.push_back(t2);
     } // If neither t1 nor t2 represent valid intersections, t_hits will remain empty
 
+    // 4. Loop over hits: generate a HitRecord for each one of them (as in the base method ray_intersection)
     std::vector<HitRecord> hits;
-    // Loop over hits: generate a HitRecord for each one of them
     for (auto t_hit :  t_hits) {
       // Compute hitting point, normal, surface coordinates
       Point hit_point = ray.at(t_hit);
       Normal normal = _normal_at_hit(hit_point, ray);
       Vec2d surface_coordinates = _surface_coordinates_at_hit(hit_point);
-
       // Build HitRecord and add to vector
       HitRecord hit{shared_from_this(), transformation * hit_point, transformation * normal, surface_coordinates, ray_world_frame,
                 t_hit};
@@ -334,16 +334,20 @@ public:
 // ------------------------------------------------------------------------------------------------------------
 
 //class CSG : public Shape {
+
 //  //-------Properties--------
 //  std::shared_ptr<Shape> object1;
 //  std::shared_ptr<Shape> object2;
 //
 //  enum class Operation { UNION, INTERSECTION, DIFFERENCE};
 //  Operation operation;
+//  //-------Constructor --------
 //
 //  CSGObject(std::shared_ptr<Shape> object1 = std::nullptr, std::shared_ptr<Shape> object2 = std::nullptr) : Shape(), object1(object1), object2(object2) {};
-//
-//  virtual std::optional<HitRecord> ray_intersection(Ray ray_world_frame) const override {
+//   
+//    // ------Methods ---------------- 
+//  
+//   virtual std::optional<HitRecord> ray_intersection(Ray ray_world_frame) const override {
 //    std::vector<HitRecord> hits = all_ray_intersections(ray_world_frame);
 //    if (hits.begin() == hits.end()) { return std::nullopt; }
 //    else { return std::make_optional<HitRecord>(hits[0]); }

--- a/include/shapes.hpp
+++ b/include/shapes.hpp
@@ -158,8 +158,8 @@ public:
     // 2. Compute the discriminant of the 2nd degree equation in slides 8b 29-31, return null if the ray is tangent (as
     // if there were no intersections)
     Vec O = ray.origin.to_vector();
-    float reduced_discriminant = std::pow(O * ray.direction, 2) - ray.direction.squared_norm() * (O.squared_norm() - 1);
-    if (reduced_discriminant == 0.f) {
+    float reduced_discriminant = std::pow(O * ray.direction, 2) - ray.direction.squared_norm() * (O.squared_norm() - 1.f);
+    if (reduced_discriminant <= 0.f || are_close(reduced_discriminant, 0.f)) {
       return std::nullopt;
     }
 
@@ -206,8 +206,8 @@ public:
     // 2. Compute the discriminant of the 2nd degree equation in slides 8b 29-31, return null if the ray is tangent (as
     // if there were no intersections)
     Vec O = ray.origin.to_vector();
-    float reduced_discriminant = std::pow(O * ray.direction, 2) - ray.direction.squared_norm() * (O.squared_norm() - 1);
-    if (reduced_discriminant == 0.f) {
+    float reduced_discriminant = std::pow(O * ray.direction, 2) - ray.direction.squared_norm() * (O.squared_norm() - 1.f);
+    if (reduced_discriminant <= 0.f || are_close(reduced_discriminant, 0.f)) {
       return std::vector<HitRecord>();
     }
 

--- a/samples/csg_example.txt
+++ b/samples/csg_example.txt
@@ -1,0 +1,39 @@
+# CSG example
+
+
+# MATERIALS
+material floor_material(diffuse(checkered(<0.3, 0.5, 0.1>, <0.1, 0.2, 0.5>, 4)),
+    uniform(<0, 0, 0>))
+
+material sky_material(diffuse(uniform(<0, 0, 0>)),
+    uniform(<0.2, 0.3, 1>))
+
+material sphere_material_1(specular(uniform(<0.5, 0.5, 0.5>)),
+    uniform(<0, 0, 0>))
+
+material sphere_material_2(diffuse(uniform(<0.8, 0.1, 0>)),
+    uniform(<0, 0, 0>))
+
+material csg_plane_material(diffuse(uniform(<0.5, 0, 0.4>)),
+    uniform(<0, 0, 0>))
+
+# OBJECTS
+# floor
+plane floor(translation([0, 0, -2]), floor_material)
+
+# sky
+sphere sky(scaling([50, 50, 50]), sky_material)
+
+# CSG objects components
+norender sphere sph1(identity, sphere_material_1)
+norender sphere sph2(translation([0, -1, 0]), sphere_material_2)
+norender plane pl(scaling([-1, 1, 1]), csg_plane_material)
+
+# Combine the first two
+norender csg two_spheres(sph1, sph2, intersection, identity, infer)
+
+# Combine with the remaining one and render
+csg(two_spheres, pl, intersection, translation([0, 0, -1]), infer)
+
+# CAMERA
+camera(perspective, translation([-3, 0, 0]), exact_asp_ratio, 1)

--- a/samples/csg_example.txt
+++ b/samples/csg_example.txt
@@ -27,13 +27,17 @@ sphere sky(scaling([50, 50, 50]), sky_material)
 # CSG objects components
 norender sphere sph1(identity, sphere_material_1)
 norender sphere sph2(translation([0, -1, 0]), sphere_material_2)
-norender plane pl(scaling([-1, 1, 1]), csg_plane_material)
+norender plane pl1(scaling([1, 1, -1]), csg_plane_material)
+norender plane pl2(translation([0, 0, 0.5]), csg_plane_material)
 
 # Combine the first two
-norender csg two_spheres(sph1, sph2, intersection, identity, infer)
+norender csg first_two(sph1, sph2, intersection, identity, infer)
+
+# Combine the third
+norender csg first_three(first_two, pl1, intersection, identity, infer)
 
 # Combine with the remaining one and render
-csg(two_spheres, pl, intersection, translation([0, 0, -1]), infer)
+csg(first_three, pl2, intersection, translation([0, 0, -1]), infer)
 
 # CAMERA
 camera(perspective, translation([-3, 0, 0]), exact_asp_ratio, 1)

--- a/test/materials_Gtest.cpp
+++ b/test/materials_Gtest.cpp
@@ -60,11 +60,10 @@ HdrImage image(2, 2);
   image.set_pixel(0, 1, Color(2.f, 1.f, 3.f));
   image.set_pixel(1, 1, Color(3.f, 2.f, 1.f));
   ImagePigment pigment = ImagePigment(image);
- 
 
   EXPECT_TRUE(pigment(Vec2d(0.f, 0.f)).is_close(Color(1.f, 2.f, 3.f)));
   EXPECT_TRUE(pigment(Vec2d(0.5f, 0.f)).is_close(Color(2.f, 3.f, 1.f)));
-  EXPECT_TRUE(pigment(Vec2d(0.f, 0.5f)).is_close(Color(2.f, 1.f, 3.f)));  
+  EXPECT_TRUE(pigment(Vec2d(0.f, 0.5f)).is_close(Color(2.f, 1.f, 3.f)));
   EXPECT_TRUE(pigment(Vec2d(0.5f, 0.5f)).is_close(Color(3.f, 2.f, 1.f)));
 }
 
@@ -78,7 +77,7 @@ TEST(BRDFTest, test_specular_brdf_reflection) {
   // Setup: incident direction and surface normal
   Vec in_dir = Vec(0.f, -1.f, -1.f);
   in_dir = in_dir.normalize();
-  Normal normal = Normal(0.f, 0.f, 1.f); 
+  Normal normal = Normal(0.f, 0.f, 1.f);
   Point hit_point = Point(0.f, 0.f, 0.f); // arbitrary intersection point
 
   // Expected reflected direction
@@ -94,7 +93,6 @@ TEST(BRDFTest, test_specular_brdf_reflection) {
   Ray scattered = brdf.scatter_ray(pcg, in_dir, hit_point, normal, 1);
   Vec out_dir = scattered.direction;
   out_dir = out_dir.normalize(); // Ensure the direction is normalized
-  
 
   // Test reflected direction
   EXPECT_TRUE(out_dir.is_close(expected_out));

--- a/test/renderers_Gtest.cpp
+++ b/test/renderers_Gtest.cpp
@@ -24,9 +24,9 @@ TEST(FlatTracerTest, test_example) {
   auto brdf = std::make_shared<DiffusiveBRDF>(pigment);
   auto material = std::make_shared<Material>(brdf);
 
-  //move the sphere to the center of the screen and make it small enough to cover only the central pixel
-  auto sphere = std::make_shared<Sphere>(translation(Vec(2.f, 0.f, 0.f)) * scaling({0.2f, 0.2f, 0.2f}), material); 
-  
+  // move the sphere to the center of the screen and make it small enough to cover only the central pixel
+  auto sphere = std::make_shared<Sphere>(translation(Vec(2.f, 0.f, 0.f)) * scaling({0.2f, 0.2f, 0.2f}), material);
+
   auto world = std::make_shared<World>();
   world->add_object(sphere);
   FlatTracer renderer{world, Color()};
@@ -94,7 +94,7 @@ TEST(PathTracerTest, test_furnace) {
   auto material = std::make_shared<Material>(brdf, emitted_radiance);
 
   // 2. Build enclosing sphere and world
-  auto enclosure = std::make_shared<Sphere>(Transformation(), material); //unit sphere at the origin with material above
+  auto enclosure = std::make_shared<Sphere>(Transformation(), material); // unit sphere at the origin with material above
   auto world = std::make_shared<World>();
   world->add_object(enclosure);
 

--- a/test/scenefiles_Gtest.cpp
+++ b/test/scenefiles_Gtest.cpp
@@ -293,7 +293,8 @@ TEST(SceneTest, test_parse_scene) {
   // Check defined Shapes
   EXPECT_EQ(scene.world->objects.size(), 3);
   EXPECT_TRUE(dynamic_pointer_cast<Plane>(scene.world->objects[0]));
-  EXPECT_TRUE(scene.world->objects[0]->transformation.is_close(translation(Vec(0.f, 0.f, 100.f)) * rotation_y(degs_to_rads(150.f))));
+  EXPECT_TRUE(
+      scene.world->objects[0]->transformation.is_close(translation(Vec(0.f, 0.f, 100.f)) * rotation_y(degs_to_rads(150.f))));
   EXPECT_TRUE(dynamic_pointer_cast<Plane>(scene.world->objects[1]));
   EXPECT_TRUE(scene.world->objects[1]->transformation.is_close(Transformation()));
   EXPECT_TRUE(dynamic_pointer_cast<Sphere>(scene.world->objects[2]));

--- a/test/shapes_Gtest.cpp
+++ b/test/shapes_Gtest.cpp
@@ -230,7 +230,7 @@ TEST(PlaneTest, test_surface_coordinates) {
 // ------------------------------------------------------------------------------------------------------------
 
 
-class CSGTest : public ::testing::Test {
+class CSGSphereTest : public ::testing::Test {
 protected:
   std::shared_ptr<Sphere> sphere1;
   std::shared_ptr<Sphere> sphere2;
@@ -251,7 +251,7 @@ protected:
 };
 
 
-TEST_F(CSGTest, test_union) {
+TEST_F(CSGSphereTest, test_union) {
   csg->operation = CSGObject::Operation::UNION;
 
   auto hits1 = csg->all_ray_intersections(ray1);
@@ -272,7 +272,7 @@ TEST_F(CSGTest, test_union) {
   EXPECT_TRUE(are_close(hits3[1].t, 3.f));
 }
 
-TEST_F(CSGTest, test_intersection) {
+TEST_F(CSGSphereTest, test_intersection) {
   csg->operation = CSGObject::Operation::INTERSECTION;
 
   auto hits1 = csg->all_ray_intersections(ray1);
@@ -287,7 +287,7 @@ TEST_F(CSGTest, test_intersection) {
   ASSERT_EQ(hits3.size(), 0);
 }
 
-TEST_F(CSGTest, test_difference) {
+TEST_F(CSGSphereTest, test_difference) {
   csg->operation = CSGObject::Operation::DIFFERENCE;
 
   auto hits1 = csg->all_ray_intersections(ray1);
@@ -304,7 +304,7 @@ TEST_F(CSGTest, test_difference) {
   ASSERT_EQ(hits3.size(), 0);
   }
 
-TEST_F(CSGTest, test_fusion) {
+TEST_F(CSGSphereTest, test_fusion) {
   csg->operation = CSGObject::Operation::FUSION;
 
   auto hits1 = csg->all_ray_intersections(ray1);
@@ -323,7 +323,7 @@ TEST_F(CSGTest, test_fusion) {
   EXPECT_TRUE(are_close(hits3[1].t, 3.f));
 }
 
-TEST_F(CSGTest, test_triple_csg) {
+TEST_F(CSGSphereTest, test_triple_csg) {
   csg->operation = CSGObject::Operation::INTERSECTION;
   auto plane = std::make_shared<Plane>(translation(-0.5f*VEC_Z), std::make_shared<Material>());
   auto spearhead = std::make_shared<CSGObject>(csg, plane, CSGObject::Operation::DIFFERENCE);
@@ -347,6 +347,23 @@ TEST_F(CSGTest, test_triple_csg) {
   // TODO that this is problematic... the intersections are actually two! Decide how to handle intersections on the boundary of one of the objects
 }
 
+TEST(CSGTest, test_csg_transformation) {
+  auto sphere = std::make_shared<Sphere>();
+  auto plane = std::make_shared<Plane>(scaling({1.f, 1.f, -1.f}));
+  auto hemisphere = std::make_shared<CSGObject>(sphere, plane, CSGObject::Operation::INTERSECTION, translation(2.f*VEC_X));
+
+  Ray ray1{Point(0.f, 0.f, 2.f), -VEC_Z};
+  auto hits1 = hemisphere->all_ray_intersections(ray1);
+  ASSERT_EQ(hits1.size(), 0);
+
+  Ray ray2{Point(2.f, 0.f, 2.f), -VEC_Z};
+  auto hits2 = hemisphere->all_ray_intersections(ray2);
+  ASSERT_EQ(hits2.size(), 2);
+  EXPECT_TRUE(are_close(hits2[0].t, 1.f));
+  EXPECT_TRUE(are_close(hits2[1].t, 2.f));
+}
+
+// TODO refactor tests for CSG
 
 // ------------------------------------------------------------------------------------------------------------
 // -------------TESTS FOR WORLD-------------------------------------------------

--- a/test/shapes_Gtest.cpp
+++ b/test/shapes_Gtest.cpp
@@ -361,6 +361,10 @@ TEST(CSGTest, test_csg_transformation) {
   ASSERT_EQ(hits2.size(), 2);
   EXPECT_TRUE(are_close(hits2[0].t, 1.f));
   EXPECT_TRUE(are_close(hits2[1].t, 2.f));
+
+  ASSERT_FALSE(hemisphere->is_point_inside(Point(0.f, 0.f, 0.5f)));
+  ASSERT_TRUE(hemisphere->is_point_inside(Point(2.f, 0.f, 0.5f)));
+  ASSERT_FALSE(hemisphere->is_point_inside(Point(2.f, 0.f, -0.5f)));
 }
 
 // TODO refactor tests for CSG

--- a/test/shapes_Gtest.cpp
+++ b/test/shapes_Gtest.cpp
@@ -304,6 +304,25 @@ TEST_F(CSGTest, test_difference) {
   ASSERT_EQ(hits3.size(), 0);
   }
 
+TEST_F(CSGTest, test_fusion) {
+  csg->operation = CSGObject::Operation::FUSION;
+
+  auto hits1 = csg->all_ray_intersections(ray1);
+  ASSERT_EQ(hits1.size(), 2);
+  EXPECT_TRUE(are_close(hits1[0].t, 1.f));
+  EXPECT_TRUE(are_close(hits1[1].t, 4.f));
+
+  auto hits2 = csg->all_ray_intersections(ray2);
+  ASSERT_EQ(hits2.size(), 2);
+  EXPECT_TRUE(are_close(hits2[0].t, 1.f));
+  EXPECT_TRUE(are_close(hits2[1].t, 3.f));
+
+  auto hits3 = csg->all_ray_intersections(ray3);
+  ASSERT_EQ(hits3.size(), 2);
+  EXPECT_TRUE(are_close(hits3[0].t, 1.f));
+  EXPECT_TRUE(are_close(hits3[1].t, 3.f));
+}
+
 TEST_F(CSGTest, test_triple_csg) {
   csg->operation = CSGObject::Operation::INTERSECTION;
   auto plane = std::make_shared<Plane>(translation(-0.5f*VEC_Z), std::make_shared<Material>());


### PR DESCRIPTION
Implement CSG functionalities
- [x] Implement helper methods _normal_at_hit() and _surface_coordinates_at_hit() for Sphere and Plane
- [x] Add new virtual method Shape::all_rays_intersections(), returning a vector containing all hits with a given Ray
- [x] Add new virtual method Shape::is_inside()
- [x] Implement CSG class
- [x] Implement unit tests
- [x] Implement Operation::FUSION (optional, not really needed as of now since our materials are not semitransparent)
- [x] Allow applying a global transformation to CSGObject and allow specifying a new material, not inherited from objects 1 and 2 (properly handling members transformation and material)
- [x] Update lexer and parser
- [x] Update README
- [x] Update CHANGELOG